### PR TITLE
fix: Retention options template

### DIFF
--- a/template.go
+++ b/template.go
@@ -56,7 +56,7 @@ func (j *{{$svrType}}SvcTask) {{.Name}}(in *{{.Request}}, opts ...asynq.Option) 
 	opts = append(opts, asynq.MaxRetry({{.MaxRetry}}))
 	{{- end}}
 	{{- if .Retention }}
-	opts = append(opts, asynq.Timeout({{.Retention}}* time.Second))
+	opts = append(opts, asynq.Retention({{.Retention}}* time.Second))
 	{{- end}}
 	{{- if .Unique }}
 	opts = append(opts, asynq.Unique({{.Unique}}* time.Second))


### PR DESCRIPTION
The current retention option generates async.Timeout; asyncq.Retention should be used